### PR TITLE
Video파일 디렉토리 경로 설정 및 VideoController, VideoService 분리

### DIFF
--- a/src/main/java/com/mimo/server/MimoServerApplication.java
+++ b/src/main/java/com/mimo/server/MimoServerApplication.java
@@ -3,6 +3,7 @@ package com.mimo.server;
 
 import java.io.File;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
@@ -16,12 +17,13 @@ public class MimoServerApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(MimoServerApplication.class, args);
 	}
+	
+	@Value("${path.videoStoragePath}")
+	private String videoStoragePath;
 
 	@Bean
 	public boolean createVideoDirectory() {
-		String videoStoragePath = System.getProperty("user.dir").toString() + "/video";
 		File Folder = new File(videoStoragePath);
-
 		if (!Folder.exists()) {
 			try {
 				Folder.mkdir();

--- a/src/main/java/com/mimo/server/controller/VideoController.java
+++ b/src/main/java/com/mimo/server/controller/VideoController.java
@@ -1,21 +1,8 @@
 package com.mimo.server.controller;
 
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.UUID;
-
-import org.springframework.core.io.FileSystemResource;
-import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,13 +12,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.mimo.server.error.CustomErrorCode;
-import com.mimo.server.error.CustomException;
 import com.mimo.server.service.VideoService;
 import com.mimo.server.util.ApiUtil;
 import com.mimo.server.util.ApiUtil.ApiSuccessResult;
 
-import jakarta.servlet.ServletContext;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,56 +28,19 @@ import lombok.extern.slf4j.Slf4j;
 public class VideoController {
 	
 	private final VideoService service;
-	private final String videoStoragePath = System.getProperty("user.dir").toString() + "/video";	// videoPath Directory Path
-	ServletContext servletContext;
-
+	
 	@PostMapping("/upload")
-	public ApiSuccessResult<String> uploadVideoFile(
-			@RequestParam("video")
-			MultipartFile uploadFile, HttpServletRequest req){
-		
-		UUID uuid = UUID.randomUUID();
-		String filename = uuid.toString() + "_" + uploadFile.getOriginalFilename();
-		String filepath = videoStoragePath + "/" + filename;
-		File file = new File(filepath);
-		
-		try {
-            BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(file));
-            bos.write(uploadFile.getBytes());
-            bos.close();
-        
-        } catch (Exception e) {
-        	throw new CustomException(CustomErrorCode.VIDEO_UPLOAD_SERVER_ERROR);
-        } 
-        return ApiUtil.success(filename);
+	@Operation(summary = "동영상 파일을 업로드 합니다.")
+	public ApiSuccessResult<String> uploadVideo(@RequestParam("video") MultipartFile uploadFile, HttpServletRequest req){
+        return ApiUtil.success(service.saveVideo(uploadFile));
 	}
-	
-	@GetMapping("/download")
-	public ResponseEntity<InputStreamResource> downloadFile(String url, HttpServletRequest req) throws Exception{
-        File file = new File(videoStoragePath + "/" + url);
-        InputStreamResource isr = new InputStreamResource(new FileInputStream(file));
-        
-        return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=" + file.getName())
-                .contentType(MediaType.MULTIPART_FORM_DATA)
-                .contentLength(file.length())
-                .body(isr);
-	}
-	
-	@GetMapping("display/{url}")
-	public ResponseEntity<?> display(@PathVariable String url, HttpServletRequest req) throws Exception{
-		String path = videoStoragePath + "/" + url;
-		Resource resource =  new FileSystemResource(path);
+
+	@GetMapping(path="display/{url}")
+	@Operation(summary = "요청받은 url의 동영상 파일을 반환합니다.")
+	public ResponseEntity<Resource> display(@PathVariable String url, HttpServletRequest req){	
 		HttpHeaders httpHeaders = new HttpHeaders();
-        try {
-            Path filepath = Paths.get(path);
-            httpHeaders.add("Content-Type", Files.probeContentType(filepath));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        
-        return new ResponseEntity<>(resource, httpHeaders, HttpStatus.OK);
+		httpHeaders.add("Content-Type", "video/mp4");
+		
+        return new ResponseEntity<>(service.getVideo(url), httpHeaders, HttpStatus.OK);
 	}
 }
-
-

--- a/src/main/java/com/mimo/server/service/VideoService.java
+++ b/src/main/java/com/mimo/server/service/VideoService.java
@@ -1,7 +1,9 @@
 package com.mimo.server.service;
 
 import org.springframework.core.io.Resource;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface VideoService {
-	public Resource loadVideo(Long videoId);
+	public String saveVideo(MultipartFile uploadFile);
+	public Resource getVideo(String url);
 }

--- a/src/main/java/com/mimo/server/util/MultipartConfig.java
+++ b/src/main/java/com/mimo/server/util/MultipartConfig.java
@@ -1,5 +1,6 @@
 package com.mimo.server.util;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.MultipartConfigFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,6 +13,9 @@ import jakarta.servlet.MultipartConfigElement;
 
 @Configuration
 public class MultipartConfig {
+	
+	@Value("${path.videoStoragePath}")
+	private String videoStoragePath;
 
     @Bean
     public MultipartResolver multipartResolver() {
@@ -21,7 +25,7 @@ public class MultipartConfig {
     @Bean
     public MultipartConfigElement multipartConfigElement() {
         MultipartConfigFactory factory = new MultipartConfigFactory();
-        factory.setLocation("/Users/kangseungwoo");
+        factory.setLocation(videoStoragePath);
         factory.setMaxRequestSize(DataSize.ofMegabytes(100L *  20));
         factory.setMaxFileSize(DataSize.ofMegabytes(100L * 20));
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,5 @@ logging.level.com.mimo.server=debug
 spring.servlet.multipart.max-file-size=100MB
 spring.servlet.multipart.max-request-size=100MB
 spring.servlet.multipart.enabled=true
+# video Storage Path
+path.videoStoragePath = video


### PR DESCRIPTION
## 관련 이슈
- #11 

## 작업 내용
- 영상파일 저장경로 설정
  > <img width="356" alt="image" src="https://github.com/mini-moment/mimo-server/assets/33233593/0f04c5e0-dc73-45ce-ae0b-c08685590e51">

  > 영상파일 저장경로를 application.properties에서 하나로 관리되도록 수정했습니다.
  > 영상파일 저장경로는 ./video 입니다.  


  > <img width="365" alt="image" src="https://github.com/mini-moment/mimo-server/assets/33233593/9d3096ff-f915-43f9-8ee6-02672a6055bc">


  > @Value 어노테이션을 사용해서 영상파일 저장경로를 가져올 수 있도록 수정했습니다. (하드코딩 제거)  



- videoController, videoService 분리

## 리뷰어에게 하고싶은 말
- 비디오 다운로드 API에서 ApiSuccessResult 사용하지 않았는 데, 공부해보고 수정하도록 하겠습니다.