### PR TITLE
getPosts API 구현

### DIFF
--- a/src/main/java/com/mimo/server/controller/PostController.java
+++ b/src/main/java/com/mimo/server/controller/PostController.java
@@ -1,5 +1,14 @@
 package com.mimo.server.controller;
 
+import java.util.List;
+
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.mimo.server.dto.HashTagDto;
 import com.mimo.server.dto.PostDto;
 import com.mimo.server.dto.UserDto;
@@ -7,13 +16,11 @@ import com.mimo.server.service.HashTagService;
 import com.mimo.server.service.PostService;
 import com.mimo.server.service.UserService;
 import com.mimo.server.util.ApiUtil;
+
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 
 @RestController
@@ -54,5 +61,16 @@ public class PostController {
                 }).toList();
         hashTagService.insertHashTagList(hashTagList);
         return ApiUtil.success(true);
+    }
+    
+    @GetMapping("posts")
+    @Operation(summary = "전달받은 Post ID 리스트에 대한 Post 리스트를 반환합니다.")
+    public ApiUtil.ApiSuccessResult<List<PostDto>> getPosts(@RequestBody int[] ids){
+    	try {
+            List<PostDto> posts = postService.getPostsByIds(ids);
+            return ApiUtil.success(posts);
+        } catch (Exception e) {
+            throw e;
+        }
     }
 }

--- a/src/main/java/com/mimo/server/dao/PostDao.java
+++ b/src/main/java/com/mimo/server/dao/PostDao.java
@@ -1,9 +1,15 @@
 package com.mimo.server.dao;
 
+import java.util.List;
+
+import org.apache.ibatis.annotations.Param;
+
 import com.mimo.server.dto.PostDto;
 
 public interface PostDao {
 	public PostDto getPost(int id);
 
 	public boolean insertPost(PostDto post);
+	
+	public List<PostDto> searchPostsByIds(@Param("array") int[] ids);
 }

--- a/src/main/java/com/mimo/server/dto/PostDto.java
+++ b/src/main/java/com/mimo/server/dto/PostDto.java
@@ -2,12 +2,16 @@ package com.mimo.server.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import lombok.Setter;
 import lombok.ToString;
 
 import java.util.List;
 
 @Getter
+@Setter
+@NoArgsConstructor
 @AllArgsConstructor
 @ToString
 public class PostDto {

--- a/src/main/java/com/mimo/server/service/PostService.java
+++ b/src/main/java/com/mimo/server/service/PostService.java
@@ -1,7 +1,10 @@
 package com.mimo.server.service;
 
+import java.util.List;
+
 import com.mimo.server.dto.PostDto;
 
 public interface PostService {
     public PostDto insertPost(PostDto post);
+    public List<PostDto> getPostsByIds(int[] ids);
 }

--- a/src/main/java/com/mimo/server/service/PostServiceImpl.java
+++ b/src/main/java/com/mimo/server/service/PostServiceImpl.java
@@ -1,11 +1,15 @@
 package com.mimo.server.service;
 
+import java.util.List;
+
+import org.apache.ibatis.session.SqlSession;
+import org.springframework.stereotype.Service;
+
 import com.mimo.server.dao.PostDao;
 import com.mimo.server.dto.PostDto;
 import com.mimo.server.util.MybatisConfig;
+
 import lombok.extern.slf4j.Slf4j;
-import org.apache.ibatis.session.SqlSession;
-import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
@@ -18,4 +22,12 @@ public class PostServiceImpl implements PostService {
             return post;
         }
     }
+
+	@Override
+	public List<PostDto> getPostsByIds(int[] ids) {
+		try (SqlSession session = MybatisConfig.getSqlSession();) {
+            PostDao dao = session.getMapper(PostDao.class);
+            return dao.searchPostsByIds(ids);
+        }
+	}
 }

--- a/src/main/resources/mapper/hashtag.xml
+++ b/src/main/resources/mapper/hashtag.xml
@@ -10,4 +10,16 @@
         INTO hashtag (id, postId, tagId)
         VALUES (0, #{postId}, #{tagId});
     </insert>
+    
+    <select id="searchTagListByPostId" parameterType="int" resultType="TagDto">
+		SELECT
+			T.id
+			, T.name
+		FROM
+			hashtag H, tag T
+		WHERE
+			H.postId = #{id}
+			AND
+			H.tagId = T.id
+    </select>
 </mapper>

--- a/src/main/resources/mapper/post.xml
+++ b/src/main/resources/mapper/post.xml
@@ -4,10 +4,31 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.mimo.server.dao.PostDao">
+	<resultMap id="PostResultMap" type="PostDto">
+		<id column="id" property="id"/>
+		<result column="title" property="title"/>
+		<result column="userId" property="userId"/>
+		<result column="videoUrl" property="videoUrl"/>
+		<result column="markerId" property="markerId"/>
+		
+		<collection column="id" javaType="java.util.List" ofType="TagDto" property="tagList" select="com.mimo.server.dao.HashTagDao.searchTagListByPostId"/>
+	</resultMap>
 
     <insert id="insertPost" parameterType="postDto" useGeneratedKeys="true" keyProperty="id">
         INSERT
         INTO post (id,title, userid, videourl, markerID)
         VALUES (0,#{title}, #{userId}, #{videoUrl},#{markerId});
     </insert>
+    
+    <select id="searchPostsByIds" parameterType="int[]" resultMap="PostResultMap">
+		SELECT
+			*
+		FROM
+			post
+		WHERE
+			id IN
+			<foreach item="postId" collection="array" open="(" separator="," close=")">
+				#{postId}
+			</foreach>
+	</select>
 </mapper>


### PR DESCRIPTION
## 관련 커밋
- #22 

## 작업 내용
- Post와 관련 TagList를 가져오는 쿼리 작성 
  > <img width="1112" alt="image" src="https://github.com/mini-moment/mimo-server/assets/33233593/fa0eaa51-1ebf-4bb5-87eb-b05eef9eaf0b">
  > <img width="1109" alt="image" src="https://github.com/mini-moment/mimo-server/assets/33233593/c78924f6-1c65-4d12-8333-2643ff50188f">
  > <img width="1108" alt="image" src="https://github.com/mini-moment/mimo-server/assets/33233593/9e0e45ab-1458-4765-b82c-4b546d2b8b7c">


- getPosts API 구현 (PostDAO 수정)
- getPosts API 구현 (PostService, PostServiceImpl 수정)
- getPosts API 구현 (PostController 수정)
- PostDTO 수정
  > <img width="251" alt="image" src="https://github.com/mini-moment/mimo-server/assets/33233593/85e20d4f-ddad-4f0d-bb1a-b5da8d8251fb">  


  > 필드들을 한번에 가지고 올 수 없는 구조이기 때문에, @NoArgsConstructor를 통해 빈 객체를 생성하고, @Setter를 통해 필드값을 채울 수 있도록 PostDTO 수정했습니다.
- getPosts API 테스트
  > <img width="1288" alt="image" src="https://github.com/mini-moment/mimo-server/assets/33233593/37beaf59-b9c3-430f-915d-84304bb5b2b0">