### PR TITLE
마커 등록 API 구현 및 Post DTO 수정

### DIFF
--- a/src/main/java/com/mimo/server/dao/MapDao.java
+++ b/src/main/java/com/mimo/server/dao/MapDao.java
@@ -9,4 +9,6 @@ public interface MapDao {
 
 
     List<MarkerDto> getMarkers(HashMap<String, Object> map);
+
+    void insertMarker(MarkerDto markerDto);
 }

--- a/src/main/java/com/mimo/server/dto/MarkerDto.java
+++ b/src/main/java/com/mimo/server/dto/MarkerDto.java
@@ -1,9 +1,13 @@
 package com.mimo.server.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 @ToString
 public class MarkerDto {
 

--- a/src/main/java/com/mimo/server/dto/PostDto.java
+++ b/src/main/java/com/mimo/server/dto/PostDto.java
@@ -22,7 +22,6 @@ public class PostDto {
     private int userId;
     @NonNull
     private String videoUrl;
-    private int markerId;
     private List<TagDto> tagList;
     private String thumbnailUrl;
 }

--- a/src/main/java/com/mimo/server/service/MapService.java
+++ b/src/main/java/com/mimo/server/service/MapService.java
@@ -7,4 +7,5 @@ import java.util.*;
 public interface MapService {
 
     List<MarkerDto> getMarkers(HashMap<String, Object> location);
+    void insertMarker(MarkerDto markerDto);
 }

--- a/src/main/java/com/mimo/server/service/MapServiceImpl.java
+++ b/src/main/java/com/mimo/server/service/MapServiceImpl.java
@@ -20,4 +20,12 @@ public class MapServiceImpl implements MapService {
             return dao.getMarkers(map);
         }
     }
+
+    @Override
+    public void insertMarker(MarkerDto markerDto) {
+        try (SqlSession session = MybatisConfig.getSqlSession();) {
+            MapDao dao = session.getMapper(MapDao.class);
+            dao.insertMarker(markerDto);
+        }
+    }
 }

--- a/src/main/resources/mapper/map.xml
+++ b/src/main/resources/mapper/map.xml
@@ -5,17 +5,22 @@
 
 <mapper namespace="com.mimo.server.dao.MapDao">
     <select id="getMarkers" parameterType="hashmap" resultType="MarkerDto">
-        SELECT
-        *
+        SELECT *
         FROM marker
         WHERE (6371 * ACOS(
-        COS(RADIANS(#{latitude}))
-        * COS(RADIANS(latitude))
-        * COS(RADIANS(longitude) - RADIANS(#{longitude}))
-        + SIN(RADIANS(#{latitude}))
-        * SIN(RADIANS(latitude))
-        )) &lt; #{radius}
+                        COS(RADIANS(#{latitude}))
+                        * COS(RADIANS(latitude))
+                        * COS(RADIANS(longitude) - RADIANS(#{longitude}))
+                    + SIN(RADIANS(#{latitude}))
+                            * SIN(RADIANS(latitude))
+            )) &lt; #{radius}
     </select>
+
+    <insert id="insertMarker" parameterType="markerDto" useGeneratedKeys="true" keyProperty="id">
+        INSERT
+        INTO marker (id, postid, latitude, longitude)
+        VALUES (0, #{postId}, #{latitude}, #{longitude});
+    </insert>
 
 
 </mapper>

--- a/src/main/resources/mapper/post.xml
+++ b/src/main/resources/mapper/post.xml
@@ -9,7 +9,6 @@
 		<result column="title" property="title"/>
 		<result column="userId" property="userId"/>
 		<result column="videoUrl" property="videoUrl"/>
-		<result column="markerId" property="markerId"/>
 		<result column="thumbnail" property="videoThumbnailUrl" />
 
 		<collection column="id" javaType="java.util.List" ofType="TagDto" property="tagList" select="com.mimo.server.dao.HashTagDao.searchTagListByPostId"/>
@@ -18,8 +17,8 @@
 
     <insert id="insertPost" parameterType="postDto" useGeneratedKeys="true" keyProperty="id">
         INSERT
-        INTO post (id,title, userid, videourl, markerID, thumbnail)
-        VALUES (0,#{title}, #{userId}, #{videoUrl},#{markerId}, #{thumbnailUrl});
+        INTO post (id,title, userid, videourl,thumbnail)
+        VALUES (0,#{title}, #{userId}, #{videoUrl},#{thumbnailUrl});
     </insert>
     
     <select id="searchPostsByIds" parameterType="int[]" resultMap="PostResultMap">


### PR DESCRIPTION
## 관련 이슈
- #31 

## 작업 내용

#### Post DTO 수정
PostDto에 마커 ID가 필요없는것 같아서 제거했습니다.

#### 마커 등록 API 구현
클라이언트에서 위치 정보를 Double 형태로 받아서 Post를 등록 후 PostId를 받아서 Marker를 등록하는 API를 구현했습니다.
결과보니 잘 동작하더라고용!
사진은 Android PR에 있어요
