### PR TITLE
게시글 업로드 시간 추가 

### DIFF
--- a/src/main/java/com/mimo/server/controller/PostController.java
+++ b/src/main/java/com/mimo/server/controller/PostController.java
@@ -6,6 +6,7 @@ import com.mimo.server.service.MapService;
 import com.mimo.server.service.PostService;
 import com.mimo.server.service.UserService;
 import com.mimo.server.util.ApiUtil;
+import com.mimo.server.util.TimeUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +18,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.Collections;
 import java.util.List;
 
 
@@ -49,7 +49,8 @@ public class PostController {
                 user.getId(),
                 post.getVideoUrl(),
                 post.getTagList(),
-                thumbnailUrl
+                thumbnailUrl,
+                post.getUploadTime()
         );
         int postId = postService.insertPost(dto).getId();
         mapService.insertMarker(new MarkerDto(0, postId, latitude, longitude));
@@ -70,7 +71,9 @@ public class PostController {
     public ApiUtil.ApiSuccessResult<List<ResponsePostListDto>> getPosts(@RequestParam int[] ids) {
 
         List<ResponsePostListDto> postList = postService.getPostsByIds(ids);
-
+        postList.forEach(dto -> {
+            dto.setUploadTime(TimeUtil.calculateTimeDifference(dto.getUploadTime()));
+        });
         return ApiUtil.success(postList);
     }
 
@@ -91,7 +94,9 @@ public class PostController {
     public ApiUtil.ApiSuccessResult<List<ResponsePostListDto>> getPostsByAccessToken(@RequestHeader("Authorization") String accessToken) {
         int[] postIds = postService.getPostsIdsByAccessToken(accessToken);
         List<ResponsePostListDto> postList = postService.getPostsByIds(postIds);
-
+        postList.forEach(dto -> {
+            dto.setUploadTime(TimeUtil.calculateTimeDifference(dto.getUploadTime()));
+        });
         return ApiUtil.success(postList);
     }
 

--- a/src/main/java/com/mimo/server/dto/PostDto.java
+++ b/src/main/java/com/mimo/server/dto/PostDto.java
@@ -24,4 +24,5 @@ public class PostDto {
     private String videoUrl;
     private List<TagDto> tagList;
     private String thumbnailUrl;
+    private String uploadTime;
 }

--- a/src/main/java/com/mimo/server/dto/ResponsePostListDto.java
+++ b/src/main/java/com/mimo/server/dto/ResponsePostListDto.java
@@ -12,9 +12,7 @@ public class ResponsePostListDto {
 
     private int id;
     private String title;
-    private int userId;
     private String videoUrl;
-    private int markerId;
     private List<TagDto> tagList;
     private String videoThumbnailUrl;
     private UserDto userInfo;

--- a/src/main/java/com/mimo/server/dto/ResponsePostListDto.java
+++ b/src/main/java/com/mimo/server/dto/ResponsePostListDto.java
@@ -18,4 +18,5 @@ public class ResponsePostListDto {
     private List<TagDto> tagList;
     private String videoThumbnailUrl;
     private UserDto userInfo;
+    private String uploadTime;
 }

--- a/src/main/java/com/mimo/server/util/TimeUtil.java
+++ b/src/main/java/com/mimo/server/util/TimeUtil.java
@@ -1,0 +1,42 @@
+package com.mimo.server.util;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class TimeUtil {
+
+    private static final int MINUTE_STANDARD = 60;
+    private static final int HOUR_STANDARD = 60;
+    private static final int DAY_STANDARD = 24;
+    private static final int MONTH_STANDARD = 30;
+
+    public static String calculateTimeDifference(String uploadTimeStr) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        LocalDateTime uploadTime = LocalDateTime.parse(uploadTimeStr, formatter);
+        ZonedDateTime uploadZonedDateTime = ZonedDateTime.of(uploadTime, ZoneId.of("Asia/Seoul"));
+        ZonedDateTime currentZonedDateTime = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        Duration duration = Duration.between(uploadZonedDateTime, currentZonedDateTime);
+        return printTimeDiff(duration.getSeconds());
+    }
+
+    private static String printTimeDiff(Long diff) {
+        if (diff < MINUTE_STANDARD) {
+            return diff + "초 전";
+        } else if (diff < MINUTE_STANDARD * HOUR_STANDARD) {
+            long minutes = diff / MINUTE_STANDARD;
+            return minutes + "분 전";
+        } else if (diff < MINUTE_STANDARD * HOUR_STANDARD * DAY_STANDARD) {
+            long hours = diff / (MINUTE_STANDARD * HOUR_STANDARD);
+            return hours + "시간 전";
+        } else if (diff < MINUTE_STANDARD * HOUR_STANDARD * DAY_STANDARD * MONTH_STANDARD) {
+            long days = diff / (MINUTE_STANDARD * HOUR_STANDARD * DAY_STANDARD);
+            return days + "일 전";
+        } else {
+            long months = diff / (MINUTE_STANDARD * HOUR_STANDARD * DAY_STANDARD * MONTH_STANDARD);
+            return months + "개월 전";
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,4 @@ spring.servlet.multipart.enabled=true
 path.videoStoragePath = video
 # thumbnail Storage Path
 path.thumbnailStoragePath = thumbnail
+spring.jackson.time-zone=Asia/Seoul

--- a/src/main/resources/mapper/post.xml
+++ b/src/main/resources/mapper/post.xml
@@ -10,6 +10,7 @@
 		<result column="userId" property="userId"/>
 		<result column="videoUrl" property="videoUrl"/>
 		<result column="thumbnail" property="videoThumbnailUrl" />
+		<result column="upload_time" property="uploadTime"/>
 
 		<collection column="id" javaType="java.util.List" ofType="TagDto" property="tagList" select="com.mimo.server.dao.HashTagDao.searchTagListByPostId"/>
 		<collection column="userId" javaType="UserDto" property="userInfo" select="com.mimo.server.dao.UserDao.getUserById"/>

--- a/src/main/resources/mapper/post.xml
+++ b/src/main/resources/mapper/post.xml
@@ -7,7 +7,6 @@
 	<resultMap id="PostResultMap" type="ResponsePostListDto">
 		<id column="id" property="id"/>
 		<result column="title" property="title"/>
-		<result column="userId" property="userId"/>
 		<result column="videoUrl" property="videoUrl"/>
 		<result column="thumbnail" property="videoThumbnailUrl" />
 		<result column="upload_time" property="uploadTime"/>


### PR DESCRIPTION
## 관련 이슈
- #35 

## 작업 내용

### 게시글 업로드 시간 추가

``` 
ALTER TABLE `post`
ADD COLUMN `upload_time` TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
```
post 테이블에 upload_time이라는 TimeSTAMP을 가지는 column을 추가했습니다.
insert 되는 시점에 시간대를 자동으로 넣어주더라고요!

### 게시글 업로드 시간 차이 계산
TimeUtil이라는 클래스를 구현해서 게시글의 업로드 시간과 서버에서 요청이 들어온 시간 차이를 반환하는 메서드를 구현해봤습니다.
기준은 차이가 60초 이내라면 몇초전, 한시간 이내라면 몇분전, 24시간 기준으로 아래라면 몇시간 전,  30일 기준으로는 몇일전, 30일 이후에는 몇개월전으로 포맷을 맞춰서 내려줬습니다.
자세한 코드는 TimeUtil 보시면 될것 같아요. 그 외 responsePostListDto에서 사용되지 않는 markerId와 userInfo에 포함된 userId는 제거했어요.
<img width="972" alt="image" src="https://github.com/mini-moment/mimo-server/assets/99114456/e2a4c135-f5bf-418e-9e74-17ce4735f8b5">

게시글 등록도 테스트해본 결과 첨부해요
![image](https://github.com/mini-moment/mimo-server/assets/99114456/c1641ff9-1563-4fe7-a966-32fe67796cd1)

등록은 기존 코드 그대로 쓰시면 될 것 같아요

## 리뷰어에게 하고 싶은 말
아직까지 고민하고 있는 내용이긴 한데, 게시글에 업로드 시간을 서버에서 계산해서 내려주는것이 맞는것 같아서 서버에서 계산을 하고
안드로이드에서는 UI에 반영만 하는 방향으로 할 까 싶은데, 의견